### PR TITLE
Fix `setup.py` script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools", "cython", "numpy"]


### PR DESCRIPTION
The package wasn't able to install the required build time dependencies. Added a TOML file to specify those dependencies.